### PR TITLE
fixing default language of site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ testem.log
 Thumbs.db
 
 /.scannerwork
+package-lock.json
+yarn.lock

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent implements OnInit {
     defaultSettings = [new Settings(1, "SettingsImageText", true)];
 
     ngOnInit(): void {
-        const languages = ["pt-BR", "en", "es", "he", "fr", "ru", "ar", "hr", "hi", "ua","se"].sort();
+        const languages = ["pt-BR", "es", "he", "fr", "ru", "ar", "hr", "hi", "ua", "se","en"];  // always keep the "en" at the end, it's the default language for the website
         this.translate.addLangs(languages);
         this.translate.setDefaultLang(languages.includes(navigator.language) ? navigator.language : "en");
 


### PR DESCRIPTION
issue: #59

hey @mathkruger 

fixed the default language on the website from default Ukraine to English even do it suppose to be English as the default.
I don't know what exactly made it pick the Ukrainian language even tho it was set to English.

my way around for a fix is I removed the ".sort();" and now any language code that is in the last array table is the default so I have commented on it so no other contributor adding new language will set it on the end of the array list.

old code:
```ts
const languages = ["pt-BR", "en", "es", "he", "fr", "ru", "ar", "hr", "hi", "ua","se"].sort();
```
new code:
```ts
const languages = ["pt-BR", "es", "he", "fr", "ru", "ar", "hr", "hi", "ua", "se","en"];  // always keep the "en" at the end, it's the default language for the website

```

feel free to edit it if you think my workaround is wrong or if there are any issues.

I added pack-lock.json and yarn.lock to .gitignore so it doesn't take user update data as package.json exists.