### PR TITLE
Style/login page button overflow

### DIFF
--- a/src/app/pages/login/login-authenticate/login-authenticate.component.css
+++ b/src/app/pages/login/login-authenticate/login-authenticate.component.css
@@ -55,19 +55,17 @@
     height: 95%;
 }
 
+.Home__bottom {
+    align-self: flex-start;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+}
+
 @media screen and (max-width: 1220px) {
     .Home__Bob {
         display: none;
-    }
-}
-
-@media screen and (max-width: 610px) {
-    .Home__bottom {
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        flex-direction: column;
-        align-items: center;
     }
 }
 
@@ -96,7 +94,6 @@
     font-weight: 400;
     padding: 10px;
     border-radius: 10px;
-    width: 260px;
     display: flex;
     transition: 0.2s all;
     justify-content: center;
@@ -119,7 +116,6 @@
     align-items: flex-end;
     justify-content: center;
     height: 95px;
-    width: 260px;
     overflow: hidden;
 }
 

--- a/src/app/pages/login/login-authenticate/login-authenticate.component.css
+++ b/src/app/pages/login/login-authenticate/login-authenticate.component.css
@@ -52,7 +52,7 @@
 }
 
 .Home__LoginLogo {
-    height: 95%;
+    height: 40px;
 }
 
 .Home__bottom {
@@ -87,7 +87,6 @@
 
 .btn-login {
     border: 0;
-    height: 60px;
     background: var(--spt-green);
     color: #000000;
     font-size: 1.5em;


### PR DESCRIPTION
Responsive design issues:
1. The "Login with Spotify" button looks ok in English but when the language changes the text overflows.
2. The texts overflows for smaller screens

Solutions:
1. Removed width prop from button and animation. The button width will be given by the text width. The button container will have the width of the button. The animation will always be centered.
2. Removed login button fixed height so the text is visible at overflow. Added fixed height to inner icon.