### PR TITLE
fix(i18n): set proper country flags for each Spanish variant

### DIFF
--- a/src/assets/i18n/es-419.json
+++ b/src/assets/i18n/es-419.json
@@ -1,6 +1,6 @@
 {
     "direction": "ltr",
-    "FlagCode": "ES",
+    "FlagCode": "MX",
     "LanguageName": "Español Latinoamericano",
     "AppName": "Litefy",
 

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1,6 +1,6 @@
 {
     "direction": "ltr",
-    "FlagCode": "MX",
+    "FlagCode": "ES",
     "LanguageName": "Español",
     "AppName": "Litefy",
 


### PR DESCRIPTION
While navigating through the website, I noticed that the Spanish variations had their flags switched.

This PR aims to set them properly.

Aims to solve the issue https://github.com/mathkruger/litefy/issues/98.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img src="https://user-images.githubusercontent.com/18721359/211842864-081fc2ce-64a8-4388-a2a0-6f69c84c0794.png" width="350" /></td><td><img src="https://user-images.githubusercontent.com/18721359/211843235-455faa16-e42c-4070-9db3-6a7da0973fea.png" width="350" /></td></tr>
<tr><td><img src="https://user-images.githubusercontent.com/18721359/211842839-19a476a3-8b3c-4480-842f-fb7ef2c0ea5e.png" width="350" /></td><td><img src="https://user-images.githubusercontent.com/18721359/211843356-88ab8bca-7845-4d2b-be18-fee9a7768717.png" width="350" /></td></tr>
</table>