### PR TITLE
#118 feature: adding european portuguese language

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -146,5 +146,8 @@
       }
     }
   },
-  "defaultProject": "spotify-client"
+  "defaultProject": "spotify-client",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1,0 +1,61 @@
+{
+    "direction": "ltr",
+    "FlagCode": "PT",
+    "LanguageName": "Português",
+    "AppName": "Litefy",
+
+    "LoginDescriptionText": "Litefy. Um cliente spotify para dispositivos mais modestos",
+    "LoginText": "Acreditamos que você não precisa de um super dispositivo para curtir sua música. Acreditamos que você não precisa se manter atualizado com todas as novas tecnologias para se divertir. É por isso que existe o Litefy.",
+    "LoginButtonText": "Login com Spotify",
+
+    "SearchPlaceholderText": "Música, álbum, artista, playlist ...",
+
+    "MenuSearchText": "Pesquisar",
+    "MenuLibraryText": "Biblioteca",
+    "MenuKaraokeText": "Modo Karaoke",
+
+    "HomeArtistsText": "Seus artistas preferidos",
+    "HomeMusicsText": "Suas músicas preferidas",
+    "HomeAlbumsText": "Novos álbuns",
+    "HomePlaylistsText": "Playlists recomendadas",
+
+    "ArtistTracksText": "Músicas mais tocadas",
+    "ArtistAlbumsText": "Álbuns",
+    "ArtistRelatedText": "Artistas relacionados",
+
+    "Hello": "Oi",
+    "LibraryTracksText": "Músicas",
+    "LibraryAlbumsText": "Álbuns",
+    "LibraryPlaylistsText": "Playlists",
+
+    "MusicListTracks": "Faixa",
+    "MusicListTracksPlural": "Faixas",
+    "MusicListFollowers": "Seguidor",
+    "MusicListFollowersPlural": "Seguidores",
+    "DescriptionText": "Descrição",
+
+    "PlayingText": "A tocar",
+    "PausedText": "Pausado",
+    "NextText": "Próxima faixa",
+    "PreviousText": "Faixa anterior",
+    "ShuffleOnText": "Modo aleatório ligado",
+    "ShuffleOffText": "Modo aleatório desligado",
+
+    "ExitText": "Sair",
+    "FollowersText": "Seguidor",
+    "FollowersTextPlural": "Seguidores",
+    "ProfileText": "Perfil",
+    "SettingsText": "Configurações",
+
+    "SearchArtists": "Artistas",
+
+    "KaraokeNotFoundText": "Nenhuma letra encontrada, mas você pode tentar buscar manualmente através do botão abaixo.",
+    "KaraokeSearchText": "Buscar",
+
+    "SettingsPageTitle": "Configurações",
+    "SettingsImageText": "A carregar imagens (album, artistas, playlists, etc.)",
+
+    "MenuPodcastText": "Podcasts",
+    "PodcastsShowsText": "Shows",
+    "PodcastsEpisodesText": "Episódios"
+}

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -78,6 +78,54 @@
     {
       "src": "assets/icons/firefox/firefox-general-16-16.png",
       "sizes": "16x16"
+    },
+    {
+      "src": "assets/icons/icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "assets/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable any"
     }
   ]
 }


### PR DESCRIPTION
Changes are minimal, but while using my browser I've noticed an error to get the PT translations. This MR fixes this issue and allow us to distingue future changes in the PT-EU.

Error:
![image](https://user-images.githubusercontent.com/22208286/235452262-800c223a-15c6-4fe0-9cc0-a313b68fb95f.png)

After fix:
![image](https://user-images.githubusercontent.com/22208286/235452482-d0dbdbda-df82-4b6c-934c-a81e2cffa154.png)
