### PR TITLE
UI break on small medium screens

### DIFF
--- a/src/app/pages/home/home.component.css
+++ b/src/app/pages/home/home.component.css
@@ -23,6 +23,11 @@
 .username{
     font-size: 2.5em;
     margin-left: 1.5%;
+    margin-bottom: 32px;
+
+    @media screen and (max-width: 730px) {
+        font-size: 20px;
+    }
 }
 
 
@@ -63,12 +68,12 @@
         float: none;
         width: 99%;
     }
-    
+
     .home-sidebar-right {
         float: none;
         width: 99%;
     }
-} 
+}
 
 
 
@@ -76,15 +81,15 @@
     .homeContainer {
         padding: 0 10px;
     }
-    
+
     .homeSubContainer {
         display: grid;
         grid-template-columns: 100%;
     }
-    
+
     .home-sidebar-right {
         height: 100%;
-        overflow-y: hidden; 
+        overflow-y: hidden;
     }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -34,9 +34,13 @@ body {
     padding-bottom: 130px;
 }
 
-/* .app {
-    margin-top: 120px !important;
-} */
+.app {
+    /*
+        70px is the header width which we must take into
+        consideration when rendering the main content.
+    */
+    margin-top: 70px !important;
+}
 
 a {
     text-decoration: none !important;


### PR DESCRIPTION
**MR Description**

**Issue**: Currently, none of the app containers take into consideration the existence of the header (in terms of the its height) and, thus, the app header overlaps and hides content. Check: 
![litefy_issue](https://github.com/mathkruger/litefy/assets/15988910/d8604c86-28ed-4b66-ba99-5c2bd545e834)

**Solution**: I've implemented a solution as well as some extra UI fixes regarding the mobile view of the top content in the home page: 
![litefy_solution](https://github.com/mathkruger/litefy/assets/15988910/46ad2f5a-ea41-4d59-a821-00723d80b2c4)

**Extra gift**: My music preferences 😄 🎵 