### PR TITLE
Bug in the language switcher and the language itself #73

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,7 +35,7 @@ import { SelectPlaylistComponent } from "./pages/select-playlist/select-playlist
 import { PodcastsComponent } from './pages/podcasts/podcasts.component';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { LanguageSwitcherComponent } from './components/language-switcher/language-switcher.component';
+import { LanguageSwitcherComponent,WindowProvider } from './components/language-switcher/language-switcher.component';
 import { VolumeBoxComponent } from './components/volume-box/volume-box.component';
 import { SettingsComponent } from './pages/settings/settings.component';
 import { YoutubePlayerComponent } from './components/youtube-player/youtube-player.component';
@@ -97,7 +97,7 @@ import { MatInputModule } from '@angular/material/input';
     ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: TokenVerificationInterceptorService, multi: true },
-    PipesModule
+    PipesModule,WindowProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -35,7 +35,7 @@ import { SelectPlaylistComponent } from "./pages/select-playlist/select-playlist
 import { PodcastsComponent } from './pages/podcasts/podcasts.component';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { LanguageSwitcherComponent,WindowProvider } from './components/language-switcher/language-switcher.component';
+import { LanguageSwitcherComponent } from './components/language-switcher/language-switcher.component';
 import { VolumeBoxComponent } from './components/volume-box/volume-box.component';
 import { SettingsComponent } from './pages/settings/settings.component';
 import { YoutubePlayerComponent } from './components/youtube-player/youtube-player.component';
@@ -97,7 +97,7 @@ import { MatInputModule } from '@angular/material/input';
     ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: TokenVerificationInterceptorService, multi: true },
-    PipesModule,WindowProvider
+    PipesModule
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/language-switcher/language-switcher.component.ts
+++ b/src/app/components/language-switcher/language-switcher.component.ts
@@ -11,14 +11,14 @@ import { Injectable, Inject } from '@angular/core';
 })
 export class LanguageSwitcherComponent implements OnInit {
 
-  constructor(public translate: TranslateService, @Inject('WINDOW') private window: Window) { }
+  constructor(public translate: TranslateService) { }
 
   currentLang: any;
   languages: any[] = [];
   hidden: boolean = true;
 
   ngOnInit() {
-    const defaultLanguage = window.localStorage.getItem("languageSelected") || this.window.navigator.language.slice(0,2);
+    const defaultLanguage = window.localStorage.getItem("languageSelected") || window.navigator.language.slice(0,2);
 
 
 
@@ -53,10 +53,4 @@ export class LanguageSwitcherComponent implements OnInit {
     this.translate.use(lang.code);
     window.localStorage.setItem('languageSelected', lang.code);
   }
-}
-
-export const WindowProvider = [{ provide: "WINDOW", useFactory: getWindow }];
-
-export function getWindow(): Window {
-    return window;
 }

--- a/src/app/components/language-switcher/language-switcher.component.ts
+++ b/src/app/components/language-switcher/language-switcher.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { Injectable, Inject } from '@angular/core';
+
+
 
 @Component({
   selector: 'app-language-switcher',
@@ -8,14 +11,16 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class LanguageSwitcherComponent implements OnInit {
 
-  constructor(public translate: TranslateService) { }
+  constructor(public translate: TranslateService, @Inject('WINDOW') private window: Window) { }
 
   currentLang: any;
   languages: any[] = [];
   hidden: boolean = true;
 
   ngOnInit() {
-    const defaultLanguage = window.localStorage.getItem("languageSelected") || this.translate.getDefaultLang();
+    const defaultLanguage = window.localStorage.getItem("languageSelected") || this.window.navigator.language.slice(0,2);
+
+
 
     this.translate.getLangs().forEach(lang => {
       this.languages.push({
@@ -48,4 +53,10 @@ export class LanguageSwitcherComponent implements OnInit {
     this.translate.use(lang.code);
     window.localStorage.setItem('languageSelected', lang.code);
   }
+}
+
+export const WindowProvider = [{ provide: "WINDOW", useFactory: getWindow }];
+
+export function getWindow(): Window {
+    return window;
 }

--- a/src/app/pages/login/login-authenticate/login-authenticate.component.css
+++ b/src/app/pages/login/login-authenticate/login-authenticate.component.css
@@ -7,6 +7,7 @@
     justify-content: space-between;
     gap: 50px;
     overflow-y: auto;
+    padding-top: 100px;
 }
 
 .Home__content {


### PR DESCRIPTION
The system by which language was tracked within the device was correct. Within app-language-switcher everything remained the same except for 
this.translate.getDefaultLang(); which was replaced by 
window.navigator.language.slice(0,2);