### PR TITLE
The toolbar overlays the wording with the title. #133

### DIFF
--- a/src/app/pages/login/login-authenticate/login-authenticate.component.css
+++ b/src/app/pages/login/login-authenticate/login-authenticate.component.css
@@ -7,6 +7,7 @@
     justify-content: space-between;
     gap: 50px;
     overflow-y: auto;
+    padding-top: 100px;
 }
 
 .Home__content {


### PR DESCRIPTION
The menu is in fixed position, there are two solutions

1) The fixed is removed, so it is not visible when scrolling
2) Padding is set between the first displayed content and the toolbar.

Since the remaining part of the program was not affected by this problem I applied padding on the login